### PR TITLE
Update requirements.txt to specify package versions

### DIFF
--- a/lambda/python-monocle-s3-langchain/coffee-chatbot-python/requirements.txt
+++ b/lambda/python-monocle-s3-langchain/coffee-chatbot-python/requirements.txt
@@ -1,6 +1,6 @@
-langchain
-langchain-openai
-openai
-monocle-apptrace[aws]
-numpy
-# boto3
+langchain==1.2.0
+langchain-openai==1.1.6
+openai==2.14.0
+--extra-index-url https://okahu.jfrog.io/artifactory/api/pypi/okahu-patch-pypi/simple
+monocle-apptrace[aws]==0.7.0b2
+numpy==2.4.0


### PR DESCRIPTION
This pull request updates the dependencies in the `requirements.txt` file to use specific, pinned package versions and adds a custom package index URL. These changes help ensure consistent environments and improve reproducibility.

Dependency version pinning and repository configuration:

* Pinned the versions of `langchain`, `langchain-openai`, `openai`, `monocle-apptrace[aws]`, and `numpy` to specific releases to ensure consistent dependency management.
* Added a custom package index URL (`--extra-index-url https://okahu.jfrog.io/artifactory/api/pypi/okahu-patch-pypi/simple`) to support fetching packages from a private repository.